### PR TITLE
Update optical_flow.py

### DIFF
--- a/optical_flow.py
+++ b/optical_flow.py
@@ -36,7 +36,7 @@ def remap(img, flow, border_mode = cv2.BORDER_REFLECT_101):
 
 
 def center_crop_image(img, w, h):
-    y, x, _ = img.shape
+    y, x = img.shape[:2]
     width_indent = int((x - w) / 2)
     height_indent = int((y - h) / 2)
     cropped_img = img[height_indent:y-height_indent, width_indent:x-width_indent]


### PR DESCRIPTION
Dear Maintainer,

This minor change should enable the use of single-channel images in remap without breaking or changing the implemented functionalities.

Prior to this request, I tried using expand_dims in the input image passed to image_transform_optical_flow, but the image sent to center_crop_image would not keep the 3rd shape value (I did not investigate why since this alternative solution was trivial to implement).

Best Regards
